### PR TITLE
Limit recording length with ChucK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y sox chuck
+  - sudo apt-get install -y chuck sox
 script:
   - bash render.sh
 cache:

--- a/rec.ck
+++ b/rec.ck
@@ -1,4 +1,4 @@
-2 => int status;
+1 => int status;
 now + 5::minute => time maxLength;
 
 // should be one sample in "production"
@@ -14,7 +14,7 @@ filename => w.wavFilename;
 // temporary workaround to automatically close file on remove-shred
 null @=> w;
 
-while( status > 1 && now < maxLength) {
+while( status > 0 && now < maxLength) {
     resolution => now;
-    // vm shred count => status
+    Machine.shreds()[1] => status;
 }

--- a/render.sh
+++ b/render.sh
@@ -13,11 +13,7 @@ for i in $( ls code | grep .ck ); do
   then
     # render pcm data
     echo "data/$i.wav is being rendered"
-    chuck -s $(echo "code/$i") rec.ck:$(echo "data/$i.silent.wav")
-    # trim silence
-    sox "data/$i.silent.wav" "data/$i.wav" silence 1 0.1 0.1% reverse silence 1 0.1 0.1% reverse
-    # clean up
-    rm "data/$i.silent.wav"
+    chuck -s $(echo "code/$i") rec.ck:$(echo "data/$i.wav")
       else
     echo "data/$i.wav is cached"
   fi


### PR DESCRIPTION
I was using Sox to trim silence from audio files. Spencer then showed me
how to inspect the VM in ChucK, so I wrote that logic into rec.ck rather
than trying to do it with sox.

We still use sox to check that ChucK actually generated audio before
uploading to SoundCloud, so we do still have the dependency.
